### PR TITLE
Fixed issues with initial contract LimeFactory.sol for Solc 0.5.0 changes

### DIFF
--- a/cli-commands/init/LimeFactory.sol
+++ b/cli-commands/init/LimeFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract LimeFactory {
 
@@ -13,7 +13,7 @@ contract LimeFactory {
 
     Lime[] public limes;
 
-    function createLime(string _name, uint8 _carbohydrates, uint8 _fat, uint8 _protein) internal {
+    function createLime(string memory _name, uint8 _carbohydrates, uint8 _fat, uint8 _protein) internal {
         limes.push(Lime(_name, _carbohydrates, _fat, _protein));
         emit FreshLime(_name);
     }


### PR DESCRIPTION
The initial version of the LimeFactory.sol and the "etherlime test" was not working at all.
`Error: /C/Users/User/etherlimetest/contracts/LimeFactory.sol:1:1: SyntaxError: Source file requires different compiler version (current compiler is 0.5.0+commit.1d4f565a.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version
pragma solidity ^0.4.25;
^----------------------^`
This is the case, because of Solc 0.5.0 version.
In this version, there are some major changes to how the Solidity is compiled and the required fields.

The issues were introduced because Solc 0.5.0 doesn't support running of older pragma versions - https://solidity.readthedocs.io/en/v0.5.0/050-breaking-changes.html#interoperability-with-older-contracts
The solution is either to specify - "pragma solidity >0.4.99 <0.6.0;" or just the normal "pragma solidity ^0.5.0" - 
I did "^0.5.0" as it might be easier to understand than the other, while the other will be more future proof, but harder to understand.

Next issues are introduced on the function accepted parameters. From now on when you accept parameter in function which is array, map or struct it is mandatory to specify the storage type e.g "storage" or "memory". - https://solidity.readthedocs.io/en/v0.5.0/050-breaking-changes.html

The LimeFactory.sol createLime() function was accepting "string" which is actually an array in Solidity, so it was asking for a place to store the data. 

Commit:
- Changed the Pragma version to be ^0.5.0 so it can run on the new Solc 0.5.0
- Changed the function string parameter to be stored in Memory as it is required parameter now.