### PR TITLE
Added support for --solc-version when running `etherlime test` command

### DIFF
--- a/cli-commands/commands.js
+++ b/cli-commands/commands.js
@@ -247,10 +247,10 @@ const commands = [
 				default: 'false'
 			});
 
-            yargs.positional('solc-version', {
-                describe: 'Sets the solc version used for compiling the smart contracts. By default it use the solc version from the node modules',
-                type: 'string'
-            });
+			yargs.positional('solc-version', {
+				describe: 'Sets the solc version used for compiling the smart contracts. By default it use the solc version from the node modules',
+				type: 'string'
+			});
 
 			yargs.positional('output', {
 				describe: 'Defines the way that the logs are shown',

--- a/cli-commands/commands.js
+++ b/cli-commands/commands.js
@@ -232,7 +232,7 @@ const commands = [
 		}
 	},
 	{
-		command: 'test [path] [skip-compilation] [output]',
+		command: 'test [path] [skip-compilation] [solc-version] [output]',
 		description: 'Run all the tests that are in the test directory',
 		argumentsProcessor: (yargs) => {
 			yargs.positional('path', {
@@ -246,6 +246,11 @@ const commands = [
 				type: 'boolean',
 				default: 'false'
 			});
+
+            yargs.positional('solc-version', {
+                describe: 'Sets the solc version used for compiling the smart contracts. By default it use the solc version from the node modules',
+                type: 'string'
+            });
 
 			yargs.positional('output', {
 				describe: 'Defines the way that the logs are shown',
@@ -261,7 +266,7 @@ const commands = [
 			logger.storeOutputParameter(argv.output);
 
 			try {
-				await test.run(argv.path, argv.skipCompilation);
+				await test.run(argv.path, argv.skipCompilation, argv.solcVersion);
 			} catch (err) {
 				console.error(err);
 			} finally {

--- a/cli-commands/etherlime-test/etherlime-test.js
+++ b/cli-commands/etherlime-test/etherlime-test.js
@@ -11,7 +11,7 @@ let ethers = require('ethers');
 
 chai.use(require("./assertions"));
 
-const run = async (files, skipCompilation) => {
+const run = async (files, skipCompilation, solcVersion) => {
 	var mochaConfig = { 'useColors': true };
 	let mocha = createMocha(mochaConfig, files);
 
@@ -24,7 +24,7 @@ const run = async (files, skipCompilation) => {
 	setJSTestGlobals();
 
 	if (!skipCompilation) {
-		await compiler.run('.', undefined, undefined, false, undefined, false, true);
+		await compiler.run('.', undefined, solcVersion, false, undefined, false, true);
 	}
 
 	await runMocha(mocha);

--- a/cli-commands/etherlime-test/test.js
+++ b/cli-commands/etherlime-test/test.js
@@ -7,12 +7,12 @@ let App = require('solidity-coverage/lib/app');
 let defaultCoverageConfig = require('./coverage-config.json');
 let accounts = require('./../ganache/setup.json').accounts;
 
-const run = async (path, skipCompilation) => {
+const run = async (path, skipCompilation, solcVersion) => {
 	var config = Config.default();
 	var testDirectory = '';
 
 	if (path.includes('.js')) {
-		await etherlimeTest.run([path], skipCompilation);
+		await etherlimeTest.run([path], skipCompilation, solcVersion);
 
 		return;
 	}
@@ -25,7 +25,7 @@ const run = async (path, skipCompilation) => {
 
 	const files = await getFiles(testDirectory, config);
 
-	await etherlimeTest.run(files, skipCompilation);
+	await etherlimeTest.run(files, skipCompilation, solcVersion);
 }
 
 const getFiles = async function (testDirectory, config) {


### PR DESCRIPTION
You can now specify a `--solc-version` when executing `etherlime test` and force the compiler to work with older version of Solc.
Example `etherlime test --solc-version=0.4.24` will compile the contracts with Solc 0.4.24 and afterward run the tests.
This is fix to issue #115