### PR TITLE
Added setters for deployer parameters (#31)

### DIFF
--- a/deployer/deployer.js
+++ b/deployer/deployer.js
@@ -29,6 +29,21 @@ class Deployer {
 		logsStore.initHistoryRecord();
 	}
 
+	setWallet(wallet) {
+		this._validateInput(wallet);
+		this.wallet = wallet;
+		this.wallet = this.wallet.connect(this.provider);
+	}
+
+	setProvider(provider) {
+		this.provider = provider;
+		this.wallet = this.wallet.connect(this.provider);
+	}
+
+	setDefaultOverrides(defaultOverrides) {
+		this.defaultOverrides = defaultOverrides;
+	}
+
 	_validateInput(wallet, provider, defaultOverrides) {
 		if (!(isWallet(wallet))) {
 			throw new Error('Passed wallet is not instance of ethers Wallet');

--- a/deployer/etherlime-ganache-deployer/etherlime-ganache-deployer.js
+++ b/deployer/etherlime-ganache-deployer/etherlime-ganache-deployer.js
@@ -15,20 +15,29 @@ class EtherlimeGanacheDeployer extends JSONRPCDeployer {
 	 * @param {*} defaultOverrides [Optional] default deployment overrides
 	 */
 	constructor(privateKey = ganacheSetupConfig.accounts[0].secretKey, port = ganacheSetupConfig.defaultPort, defaultOverrides) {
-		if (!(isNumber(port))) {
-			throw new Error(`Passed port (${port}) is not valid port`);
-		}
+		EtherlimeGanacheDeployer._validatePortInput(port);
 		const nodeUrl = `http://localhost:${port}/`;
 
 		super(privateKey, nodeUrl, defaultOverrides);
 		this.nodeUrl = nodeUrl;
 	}
 
+	setPort(port) {
+		EtherlimeGanacheDeployer._validatePortInput(port);
+		const nodeUrl = `http://localhost:${port}/`;
+		this.setNodeUrl(nodeUrl);
+	}
+
+	static _validatePortInput(port) {
+		if (!isNumber(port)) {
+			throw new Error(`Passed port (${port}) is not valid port`);
+		}
+	}
+
 	toString() {
 		const superString = super.toString();
 		return `Network: ${colors.colorNetwork(this.nodeUrl)}\n${superString}`;
 	}
-
 
 	async _waitForDeployTransaction(transaction) {
 		await this.provider.send('evm_mine');

--- a/deployer/infura-deployer/infura-private-key-deployer.js
+++ b/deployer/infura-deployer/infura-private-key-deployer.js
@@ -26,6 +26,19 @@ class InfuraPrivateKeyDeployer extends PrivateKeyDeployer {
 		this.apiKey = apiKey;
 	}
 
+	setNetwork(network) {
+		const infuraNetwork = ethers.utils.getNetwork(network);
+		const infuraProvider = new ethers.providers.InfuraProvider(infuraNetwork, this.apiKey);
+		this.setProvider(infuraProvider);
+		this.network = network;
+	}
+
+	setApiKey(apiKey) {
+		const infuraProvider = new ethers.providers.InfuraProvider(this.infuraNetwork, apiKey);
+		this.setProvider(infuraProvider);
+		this.apiKey = apiKey;
+	}
+
 	toString() {
 		const superString = super.toString();
 		return `Deployer set to Infura. Network: ${colors.colorNetwork(this.network)} with API Key: ${colors.colorAPIKey(this.apiKey)}\n${superString}`;

--- a/deployer/jsonrpc-deployer/jsonrpc-private-key-deployer.js
+++ b/deployer/jsonrpc-deployer/jsonrpc-private-key-deployer.js
@@ -16,14 +16,27 @@ class JSONRPCPrivateKeyDeployer extends PrivateKeyDeployer {
 	 * @param {*} defaultOverrides [Optional] default deployment overrides
 	 */
 	constructor(privateKey, nodeUrl, defaultOverrides) {
-		if (!(isUrl(nodeUrl))) {
-			throw new Error(`Passed contract url (${nodeUrl}) is not valid url`);
-		}
+		JSONRPCPrivateKeyDeployer._validateUrlInput(nodeUrl);
+
 		const localNodeProvider = new ethers.providers.JsonRpcProvider(nodeUrl);
 		super(privateKey, localNodeProvider, defaultOverrides);
 		this.nodeUrl = nodeUrl;
 
 		logger.log(`JSONRPC Deployer Network: ${colors.colorNetwork(this.nodeUrl)}`);
+	}
+
+	setNodeUrl(nodeUrl) {
+		JSONRPCPrivateKeyDeployer._validateUrlInput(nodeUrl);
+
+		const localNodeProvider = new ethers.providers.JsonRpcProvider(nodeUrl);
+		this.setProvider(localNodeProvider);
+		this.nodeUrl = nodeUrl;
+	}
+
+	static _validateUrlInput(nodeUrl) {
+		if (!(isUrl(nodeUrl))) {
+			throw new Error(`Passed contract url (${nodeUrl}) is not valid url`);
+		}
 	}
 
 	toString() {

--- a/deployer/private-key-deployer.js
+++ b/deployer/private-key-deployer.js
@@ -17,8 +17,14 @@ class PrivateKeyDeployer extends Deployer {
 		const wallet = new ethers.Wallet(sanitizedPrivateKey, provider);
 
 		super(wallet, provider, defaultOverrides);
-		
+
 		logger.log(`Deployer set to deploy from address: ${colors.colorAddress(this.wallet.address)}\n`);
+	}
+
+	setPrivateKey(privateKey) {
+		const sanitizedPrivateKey = (privateKey.startsWith('0x')) ? privateKey : `0x${privateKey}`;
+		const wallet = new ethers.Wallet(sanitizedPrivateKey, this.provider);
+		this.setWallet(wallet);
 	}
 
 	toString() {

--- a/test/config.json
+++ b/test/config.json
@@ -9,9 +9,12 @@
   "defaultGasPrice": 50000000000,
   "defaultGasLimit": 4700000,
   "nodeUrl": "http://localhost:8545/",
+  "alternativeNodeUrl": "http://localhost:9545/",
   "ganacheCliPrivateKey": "7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8",
   "ganacheCliPort": 8545,
+  "alternativePort": 9545,
   "infuraForkAPIKey": "abca6d1110b443b08ef271545f24b80d",
+  "alternativeApiKey": "fdcadd1410c443e08ff281545f24b70a",
   "specificBlockNumber": 2,
   "deployedContractAddress": "0x78ed7A34D67fB3eAc745e7af78aE1bcA770C26de",
   "localPrivateKey": "0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8"

--- a/test/deployer/deployer.js
+++ b/test/deployer/deployer.js
@@ -54,6 +54,72 @@ describe('Deployer tests', () => {
 		})
 	});
 
+	describe('Setters', () => {
+		it('should set wallet', () => {
+			const provider = new ethers.providers.JsonRpcProvider(config.nodeUrl);
+			const initialWallet = new ethers.Wallet('0x' + config.randomPrivateKey);
+			const deployer = new etherlime.Deployer(initialWallet, provider, defaultConfigs);
+
+			const newWallet = new ethers.Wallet('0x' + config.ganacheCliPrivateKey);
+			deployer.setWallet(newWallet);
+
+			assert.deepEqual(newWallet.signingKey, deployer.wallet.signingKey, "The stored wallet does not match the new one");
+
+			assert.deepEqual(provider, deployer.provider, "The stored provider does not match the inputted one");
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+			assert.deepEqual(provider, deployer.wallet.provider, "The provider of the wallet does not match the inputted provider");
+		});
+
+		it('should throw on incorrect wallet string', () => {
+			const provider = new ethers.providers.JsonRpcProvider(config.nodeUrl);
+			const initialWallet = new ethers.Wallet('0x' + config.randomPrivateKey);
+			const deployer = new etherlime.Deployer(initialWallet, provider, defaultConfigs);
+
+			const throwingFunction = () => {
+				deployer.setWallet('Random Things Here');
+			};
+
+			assert.throws(throwingFunction, "The deployer did not throw with invalid wallet");
+		});
+
+		it('should throw on incorrect wallet input type', () => {
+			const provider = new ethers.providers.JsonRpcProvider(config.nodeUrl);
+			const initialWallet = new ethers.Wallet('0x' + config.randomPrivateKey);
+			const deployer = new etherlime.Deployer(initialWallet, provider, defaultConfigs);
+
+			const throwingFunction = () => {
+				deployer.setWallet(69);
+			};
+
+			assert.throws(throwingFunction, "The deployer did not throw with invalid wallet");
+		})
+
+		it('should set provider', () => {
+			const initialProvider = new ethers.providers.JsonRpcProvider(config.nodeUrl);
+			const wallet = new ethers.Wallet('0x' + config.randomPrivateKey);
+			const deployer = new etherlime.Deployer(wallet, initialProvider, defaultConfigs);
+
+			const newProvider = new ethers.providers.JsonRpcProvider('http://localhost:9545/');
+			deployer.setProvider(newProvider);
+
+			assert.deepEqual(newProvider, deployer.provider, "The stored provider does not match the new one");
+			assert.deepEqual(newProvider, deployer.wallet.provider, "The provider of the wallet does not match the new provider");
+
+			assert.deepEqual(wallet.signingKey, deployer.wallet.signingKey, "The stored wallet does not match the inputted one");
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+		});
+
+		it('should set defaultOverrides', () => {
+			const provider = new ethers.providers.JsonRpcProvider(config.nodeUrl);
+			const wallet = new ethers.Wallet('0x' + config.randomPrivateKey);
+			const deployer = new etherlime.Deployer(wallet, provider);
+
+			deployer.setDefaultOverrides(defaultConfigs);
+
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+		});
+	});
+
 	describe('Deploying contract', async () => {
 
 		let wallet;

--- a/test/deployer/deployer.js
+++ b/test/deployer/deployer.js
@@ -99,7 +99,7 @@ describe('Deployer tests', () => {
 			const wallet = new ethers.Wallet('0x' + config.randomPrivateKey);
 			const deployer = new etherlime.Deployer(wallet, initialProvider, defaultConfigs);
 
-			const newProvider = new ethers.providers.JsonRpcProvider('http://localhost:9545/');
+			const newProvider = new ethers.providers.JsonRpcProvider(config.alternativeNodeUrl);
 			deployer.setProvider(newProvider);
 
 			assert.deepEqual(newProvider, deployer.provider, "The stored provider does not match the new one");

--- a/test/deployer/etherlime-ganache-deployer/etherlime-ganache-deployer.js
+++ b/test/deployer/etherlime-ganache-deployer/etherlime-ganache-deployer.js
@@ -70,7 +70,7 @@ describe('GanacheCli-Deployer tests', () => {
 
 	describe('Setters', () => {
 		it('should set port', () => {
-			const port = 9545;
+			const port = config.alternativePort;
 
 			const deployer = new etherlime.EtherlimeGanacheDeployer();
 			deployer.setPort(port);

--- a/test/deployer/etherlime-ganache-deployer/etherlime-ganache-deployer.js
+++ b/test/deployer/etherlime-ganache-deployer/etherlime-ganache-deployer.js
@@ -32,13 +32,11 @@ describe('GanacheCli-Deployer tests', () => {
 		it('Should take default value on empty port', () => {
 			const deployer = new etherlime.EtherlimeGanacheDeployer(config.ganacheCliPrivateKey, undefined, defaultConfigs);
 			assert.deepEqual(config.nodeUrl, deployer.provider.connection.url, "The stored provider url does not match the inputted one");
-
 		})
 
 		it('Should take default value on empty privateKey', () => {
 			const deployer = new etherlime.EtherlimeGanacheDeployer(undefined, config.ganacheCliPort, defaultConfigs);
 			assert.deepEqual(defaultPrivateKey, deployer.wallet.privateKey, "The stored provider privateKey does not match the inputted one");
-
 		})
 
 		it('Should take default values on empty privateKey and port', () => {
@@ -48,7 +46,6 @@ describe('GanacheCli-Deployer tests', () => {
 		})
 
 		it('should deploy contract without default configs', async () => {
-
 			deployer = new etherlime.EtherlimeGanacheDeployer();
 			const contractWrapper = await deployer.deploy(Greetings);
 
@@ -61,7 +58,6 @@ describe('GanacheCli-Deployer tests', () => {
 			}
 
 			assert.throws(throwingFunction, "The deployer did not throw with invalid nodeUrl");
-
 		})
 
 		it('Provider method toString should return string', () => {
@@ -71,6 +67,29 @@ describe('GanacheCli-Deployer tests', () => {
 			assert(returnedString.includes(config.nodeUrl), `The returned toString method did not contain ${config.nodeUrl}`)
 		})
 	})
+
+	describe('Setters', () => {
+		it('should set port', () => {
+			const port = 9545;
+
+			const deployer = new etherlime.EtherlimeGanacheDeployer();
+			deployer.setPort(port);
+
+			const expectedNodeUrl = `http://localhost:${port}/`;
+			assert.deepEqual(expectedNodeUrl, deployer.provider.connection.url, "The stored provider url does not match the expected one");
+
+			assert.deepEqual(defaultPrivateKey, deployer.wallet.privateKey, "The stored provider privateKey does not match the inputted one");
+		});
+
+		it('Should throw on string for port', () => {
+			const deployer = new etherlime.EtherlimeGanacheDeployer();
+			const throwingFunction = () => {
+				deployer.setPort('69');
+			}
+
+			assert.throws(throwingFunction, "The deployer did not throw with invalid port");
+		});
+	});
 
 	describe('Wrapping deployed contract', async () => {
 

--- a/test/deployer/infura-deployer/infura-private-key-deployer.js
+++ b/test/deployer/infura-deployer/infura-private-key-deployer.js
@@ -25,5 +25,33 @@ describe('Infura private key tests', () => {
 			assert(typeof returnedString === 'string', "The returned toString method did not return string");
 			assert(returnedString.includes('Infura'), `The returned toString method did not contain Infura`)
 		})
-	})
+	});
+
+	describe('Setters', () => {
+		it('Should set network', () => {
+			const deployer = new etherlime.InfuraPrivateKeyDeployer(config.infuraPrivateKey, config.infuraNetwork, config.infuraAPIKey, defaultConfigs);
+
+			const newNetwork = 'ropsten';
+			deployer.setNetwork(newNetwork);
+
+			assert.deepEqual(newNetwork, deployer.network, "The stored provider network does not match the new one");
+
+			assert.deepEqual(config.infuraAPIKey, deployer.apiKey, "The stored provider api key does not match the inputted one");
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+			assert.deepEqual('0x' + config.infuraPrivateKey, deployer.wallet.privateKey, "The stored wallet does not match the inputted one");
+		});
+
+		it('Should set api key', () => {
+			const deployer = new etherlime.InfuraPrivateKeyDeployer(config.infuraPrivateKey, config.infuraNetwork, config.infuraAPIKey, defaultConfigs);
+
+			const newApiKey = 'Up5uvBHSCSqtOmnlhL05';
+			deployer.setApiKey(newApiKey);
+
+			assert.deepEqual(newApiKey, deployer.apiKey, "The stored provider api key does not match the inputted one");
+
+			assert.deepEqual(config.infuraNetwork, deployer.network, "The stored provider network does not match the inputted one");
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+			assert.deepEqual('0x' + config.infuraPrivateKey, deployer.wallet.privateKey, "The stored wallet does not match the inputted one");
+		});
+	});
 });

--- a/test/deployer/infura-deployer/infura-private-key-deployer.js
+++ b/test/deployer/infura-deployer/infura-private-key-deployer.js
@@ -44,7 +44,7 @@ describe('Infura private key tests', () => {
 		it('Should set api key', () => {
 			const deployer = new etherlime.InfuraPrivateKeyDeployer(config.infuraPrivateKey, config.infuraNetwork, config.infuraAPIKey, defaultConfigs);
 
-			const newApiKey = 'Up5uvBHSCSqtOmnlhL05';
+			const newApiKey = config.alternativeApiKey;
 			deployer.setApiKey(newApiKey);
 
 			assert.deepEqual(newApiKey, deployer.apiKey, "The stored provider api key does not match the inputted one");

--- a/test/deployer/jsonrpc-deployer/jsonrpc-private-key-deployer.js
+++ b/test/deployer/jsonrpc-deployer/jsonrpc-private-key-deployer.js
@@ -23,7 +23,6 @@ describe('JSONRPC-Private-Key-Deployer tests', () => {
 			}
 
 			assert.throws(throwingFunction, "The deployer did not throw with invalid nodeUrl");
-
 		})
 
 		it('Should throw on number for nodeUrl', () => {
@@ -32,7 +31,6 @@ describe('JSONRPC-Private-Key-Deployer tests', () => {
 			}
 
 			assert.throws(throwingFunction, "The deployer did not throw with invalid nodeUrl");
-
 		})
 
 		it('Provider method toString should return string', () => {
@@ -41,5 +39,37 @@ describe('JSONRPC-Private-Key-Deployer tests', () => {
 			assert(typeof returnedString === 'string', "The returned toString method did not return string");
 			assert(returnedString.includes(config.nodeUrl), `The returned toString method did not contain ${config.nodeUrl}`)
 		})
-	})
+	});
+
+	describe('Setters', () => {
+		it('should set nodeUrl', () => {
+			const deployer = new etherlime.JSONRPCPrivateKeyDeployer(config.randomPrivateKey, config.nodeUrl, defaultConfigs);
+
+			const newNodeUrl = 'http://localhost:9545/';
+			deployer.setNodeUrl(newNodeUrl);
+
+			assert.deepEqual(newNodeUrl, deployer.provider.connection.url, "The stored provider url does not match the inputted one");
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+		});
+
+		it('Should throw on empty nodeUrl', () => {
+			const deployer = new etherlime.JSONRPCPrivateKeyDeployer(config.randomPrivateKey, config.nodeUrl, defaultConfigs);
+
+			const throwingFunction = () => {
+				deployer.setNodeUrl('');
+			}
+
+			assert.throws(throwingFunction, "The deployer did not throw with invalid nodeUrl");
+		});
+
+		it('Should throw on number for nodeUrl', () => {
+			const deployer = new etherlime.JSONRPCPrivateKeyDeployer(config.randomPrivateKey, config.nodeUrl, defaultConfigs);
+
+			const throwingFunction = () => {
+				deployer.setNodeUrl(69);
+			}
+
+			assert.throws(throwingFunction, "The deployer did not throw with invalid nodeUrl");
+		});
+	});
 });

--- a/test/deployer/jsonrpc-deployer/jsonrpc-private-key-deployer.js
+++ b/test/deployer/jsonrpc-deployer/jsonrpc-private-key-deployer.js
@@ -45,7 +45,7 @@ describe('JSONRPC-Private-Key-Deployer tests', () => {
 		it('should set nodeUrl', () => {
 			const deployer = new etherlime.JSONRPCPrivateKeyDeployer(config.randomPrivateKey, config.nodeUrl, defaultConfigs);
 
-			const newNodeUrl = 'http://localhost:9545/';
+			const newNodeUrl = config.alternativeNodeUrl;
 			deployer.setNodeUrl(newNodeUrl);
 
 			assert.deepEqual(newNodeUrl, deployer.provider.connection.url, "The stored provider url does not match the inputted one");

--- a/test/deployer/private-key-deployer.js
+++ b/test/deployer/private-key-deployer.js
@@ -15,13 +15,13 @@ const defaultConfigs = {
 
 describe('Private key deployer tests', () => {
 
+	let provider;
+
+	beforeEach(() => {
+		provider = new ethers.providers.JsonRpcProvider(config.nodeUrl);
+	})
+
 	describe('Initialization', async () => {
-
-		let provider;
-
-		beforeEach(() => {
-			provider = new ethers.providers.JsonRpcProvider(config.nodeUrl);
-		})
 
 		it('should initialize the wallet with correct private key without 0x', () => {
 
@@ -58,5 +58,31 @@ describe('Private key deployer tests', () => {
 		})
 	})
 
+	describe('Setters', () => {
+		it('should set private key without 0x', () => {
+			const privateKey = config.ganacheCliPrivateKey;
 
+			const deployer = new etherlime.PrivateKeyDeployer(config.randomPrivateKey, provider, defaultConfigs);
+			deployer.setPrivateKey(privateKey);
+
+			assert.deepEqual('0x' + privateKey, deployer.wallet.privateKey, "The stored wallet does not match the inputted one");
+
+			assert.deepEqual(provider, deployer.provider, "The stored provider does not match the inputted one");
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+			assert.deepEqual(provider, deployer.wallet.provider, "The provider of the wallet does not match the inputted provider");
+		});
+
+		it('should set private key with 0x', () => {
+			const privateKey = '0x' + config.ganacheCliPrivateKey;
+
+			const deployer = new etherlime.PrivateKeyDeployer(config.randomPrivateKey, provider, defaultConfigs);
+			deployer.setPrivateKey(privateKey);
+
+			assert.deepEqual(privateKey, deployer.wallet.privateKey, "The stored wallet does not match the inputted one");
+
+			assert.deepEqual(provider, deployer.provider, "The stored provider does not match the inputted one");
+			assert.deepEqual(defaultConfigs, deployer.defaultOverrides, "The stored default overrides does not match the inputted one");
+			assert.deepEqual(provider, deployer.wallet.provider, "The provider of the wallet does not match the inputted provider");
+		});
+	});
 });


### PR DESCRIPTION
- Added setters for all constructor parameters in all deployer classes
- Added tests to check that the setters work, and don't change anything else

I had some trouble running `npm test`, but `mocha test/deployer/**.js` passed all tests.