### PR TITLE
Add lcov output to `coverage`

### DIFF
--- a/packages/etherlime/cli-commands/etherlime-test/etherlime-coverage.js
+++ b/packages/etherlime/cli-commands/etherlime-test/etherlime-coverage.js
@@ -184,6 +184,7 @@ const generateCoverageReports = async (shouldOpenCoverage) => {
 	collector.add(coverageFile);
 	reporter.add(['text']);
 	reporter.add(['html']);
+	reporter.add(['lcov']);
 
 	setTimeout(async () => {
 		console.log();


### PR DESCRIPTION
lcov is a standardized format that is used by tools like https://coveralls.io/ and other automated coverage tools. This commit adds lcov output to the coverage command.