### PR TITLE
refactor: etherlime test optional parameter

### DIFF
--- a/doc/developer-documentation/etherlime-cli/test.md
+++ b/doc/developer-documentation/etherlime-cli/test.md
@@ -5,7 +5,7 @@
 ### Syntax
 
 ```text
-etherlime test [path] [timeout] [skip-compilation] [gas-report] [runs] [solc-version]
+etherlime test [path] [timeout] [skip-compilation] [gas-report] [runs] [solcVersion]
 [output] [port]
 ```
 
@@ -39,7 +39,7 @@ Parameters:
 
   run. By default the optimizer is not enabled.
 
-* `solc-version` - \[Optional\] By specifying `solc-version` you can
+* `solcVersion` - \[Optional\] By specifying `solcVersion` you can
 
   set the version of the solc which will be used for compiling the
 

--- a/docs/source/cli/test.rst
+++ b/docs/source/cli/test.rst
@@ -6,7 +6,7 @@ Syntax
 
 ::
 
-    etherlime test [path] [timeout] [skip-compilation] [gas-report] [runs] [solc-version] [output] [port]
+    etherlime test [path] [timeout] [skip-compilation] [gas-report] [runs] [solcVersion] [output] [port]
 
 Parameters:
 
@@ -15,7 +15,7 @@ Parameters:
 * ``skip-compilation`` - [Optional] This parameter controls wether a compilation will be ran before the tests are started. Default: false.
 * ``gas-report`` - [Optional] Enables Gas reporting future that will show Gas Usage after each test. Default: false.
 * ``runs`` - [Optional] By specifying ``runs`` between 1 and 999 you enabled the optimizer and set how many times the optimizer will be run. By default the optimizer is not enabled.
-* ``solc-version`` - [Optional] By specifying ``solc-version`` you can set the version of the solc which will be used for compiling the smart contracts. By default it use the solc version from the node_modules folder.
+* ``solcVersion`` - [Optional] By specifying ``solcVersion`` you can set the version of the solc which will be used for compiling the smart contracts. By default it use the solc version from the node_modules folder.
 * ``output`` - [Optional] Defines the way that the logs are shown. Choices: ``none`` - silences the output of logs, ``normal`` - see verbose logs in the console and ``structured`` - structured output in a file meant for inter program communication.
 * ``port`` - [Optional] The port that the etherlime ganache is runing. Used for wiring up the default accounts correctly. Defaults to 8545
 

--- a/packages/etherlime/cli-commands/commands.js
+++ b/packages/etherlime/cli-commands/commands.js
@@ -299,7 +299,7 @@ const commands = [{
 		}
 	},
 	{
-		command: 'test [path] [timeout] [skip-compilation] [gas-report] [runs] [solc-version] [output] [port]',
+		command: 'test [path] [timeout] [skip-compilation] [gas-report] [runs] [solcVersion] [output] [port]',
 		description: 'Run all the tests that are in the test directory',
 		argumentsProcessor: (yargs) => {
 			yargs.positional('path', {
@@ -325,7 +325,7 @@ const commands = [{
 				type: 'number'
 			});
 
-			yargs.positional('solc-version', {
+			yargs.positional('solcVersion', {
 				describe: 'Sets the solc version used for compiling the smart contracts. By default it use the solc version from the node modules',
 				type: 'string'
 			});


### PR DESCRIPTION
Rename solc-version -> solcVersion, due to inconsistency in other cli commands
docs: solc-version -> solcVersion